### PR TITLE
Update 99-tomtom.rules

### DIFF
--- a/99-tomtom.rules
+++ b/99-tomtom.rules
@@ -1,4 +1,4 @@
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1390", ATTRS{idProduct}=="7474", SYMLINK+="tomtom", GROUP="usb", MODE="660"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1390", ATTRS{idProduct}=="7475", SYMLINK+="tomtom", GROUP="usb", MODE="660"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1390", ATTRS{idProduct}=="7476", SYMLINK+="tomtom", GROUP="usb", MODE="660"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1390", ATTRS{idProduct}=="7477", SYMLINK+="tomtom", GROUP="usb", MODE="660"
-


### PR DESCRIPTION
issue #126 : udev rule for permission to allow access to the tomtom runner 3 cardio+music through USB by a unprivileged user.